### PR TITLE
Change icon for international events

### DIFF
--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -60,8 +60,13 @@
               <div class="event__delivery">
                 <span class="sr-only">Location:</span>
                 <span class="event__location">
-                  <i class="fa-solid fa-fw fa-location-dot"></i>
-                  <span itemprop="location" itemscope itemtype="https://schema.org/Place">{{ event.location | default: 'International' }}</span>
+                  {% if event.location %}
+                    <i class="fa-solid fa-fw fa-location-dot"></i>
+                    <span itemprop="location" itemscope itemtype="https://schema.org/Place">{{ event.location }}</span>
+                  {% else %}
+                    <i class="fa-solid fa-fw fa-globe"></i>
+                    <span itemprop="location" itemscope itemtype="https://schema.org/Place">International</span>
+                  {% endif %}
                 </span>
               </div>
             </article>

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -62,8 +62,13 @@ layout: layouts/base.liquid
               <div class="event__delivery">
                 <span class="sr-only">Location:</span>
                 <span class="event__location">
+                  {% if event.location %}
                   <i class="fa-solid fa-fw fa-location-dot"></i>
-                  <span itemprop="location" itemscope itemtype="https://schema.org/Place">{{ event.location | default: 'International' }}</span>
+                  <span itemprop="location" itemscope itemtype="https://schema.org/Place">{{ event.location }}</span>
+                  {% else %}
+                  <i class="fa-solid fa-fw fa-globe"></i>
+                  <span itemprop="location" itemscope itemtype="https://schema.org/Place">International</span>
+                  {% endif %}
                 </span>
               </div>
             </article>


### PR DESCRIPTION
Displays a globe icon instead of location pin for international events, i.e. offline events that do not have an explicit location.