### PR TITLE
56 events from different years are appearing in the same month

### DIFF
--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -92,18 +92,20 @@ export default async (request, context) => {
         const months = [];
         // Loop through each event
         events.forEach((event) => {
-          // Get the month of the event
+          // Get the month and year of the event
           const month = new dayjs(event.dateStart).format("MMMM");
-          // Check if the month already exists in the array
-          const monthIndex = months.findIndex((m) => m.name === month);
-          // If the month doesn't exist, add it to the array
+          const year = new dayjs(event.dateStart).format("YYYY");
+          // Check if the month and year already exist in the array
+          const monthIndex = months.findIndex((m) => m.month === month && m.year === year);
+          // If the month and year don't exist, add them to the array
           if (monthIndex === -1) {
             months.push({
-              name: month,
+              month: month,
+              year: year,
               events: [event],
             });
           } else {
-            // If the month does exist, add the event to the array
+            // If the month and year do exist, add the event to the array
             months[monthIndex].events.push(event);
           }
         });

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -22,7 +22,8 @@ layout: layouts/base.liquid
         {% for month in groupedEvents %}
           <section id="{{ month.name }}" class="month">
             <div class="container readable flow">
-              <h2 class="month__heading">{{ month.name }}</h2>
+              {% assign currentYear = 'now' | date: "%Y" %}
+              <h2 class="month__heading">{{ month.month }}{% if month.year != currentYear %} {{ month.year }}{% endif %}</h2>
               {% for event in month.events %}
               {%- if event.type == "theme" %}
                 <article


### PR DESCRIPTION
The `groupByMonth` filter now captures both month and year, making both available as keys in the returned array. In the template, we now display both month and year if the current year does not match the year in the array.