### PR TITLE
55 display the duration of child events

### DIFF
--- a/src/index.liquid
+++ b/src/index.liquid
@@ -269,10 +269,11 @@ layout: layouts/base.liquid
                                           </abbr>
                                         </time>
                                       </span>
+                                      <meta itemprop="endDate" content="{{ child.dateEnd }}" />
                                       ·
                                       <span class="event__duration">
                                         <span class="sr-only">Duration</span>
-                                        <time datetime="{{ child.dateEnd }}" itemprop="endDate">
+                                        <time datetime="PT{{ duration_minutes }}M" itemprop="duration">
                                           <i class="fa-solid fa-timer"></i>
                                           {{ duration_minutes }} minutes
                                         </time>
@@ -287,10 +288,11 @@ layout: layouts/base.liquid
                                           </abbr>
                                         </time>
                                       </span>
+                                      <meta itemprop="endDate" content="{{ child.dateEnd }}" />
                                       ·
                                       <span class="event__duration">
                                         <span class="sr-only">Duration</span>
-                                        <time datetime="{{ child.dateEnd }}" itemprop="endDate">
+                                        <time datetime="PT{{ duration_minutes }}M" itemprop="duration">
                                           <i class="fa-solid fa-timer"></i>
                                           {{ duration_minutes }} minutes
                                         </time>

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -260,20 +260,11 @@ layout: layouts/base.liquid
                                     {% assign duration_seconds = end_date | minus: start_date %}
                                     {% assign duration_minutes = duration_seconds | divided_by: 60 %}
 
-                                    {% if parentEndDate == nil %}
+                                    {% if parentEndDate == nil or parentStartDate == parentEndDate %}
                                       <span class="event__dateStart">
                                         <time datetime="{{ child.dateStart }}" itemprop="startDate">
                                           {{ child.dateStart | localizeDate: "h:mm A" }}
                                           <abbr title="{{ child.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                            {{ child.dateStart | localizeDate: 'z' }}
-                                          </abbr>
-                                        </time>
-                                      </span>
-                                    {% elsif parentStartDate == parentEndDate %}
-                                      <span class="event__dateStart">
-                                        <time datetime="{{ child.dateStart }}" itemprop="startDate">
-                                          {{ child.dateStart | localizeDate: "h:mm A" }}
-                                          <abbr title="{{ child.dateStart | localizeDate: 'z' | expandTimezone }}">
                                             {{ child.dateStart | localizeDate: 'z' }}
                                           </abbr>
                                         </time>

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -278,14 +278,12 @@ layout: layouts/base.liquid
                                           </abbr>
                                         </time>
                                       </span>
-                                      <span class="event__dateEnd">
-                                        <i class="fa-solid fa-arrow-right-long"></i>
-                                        <span class="sr-only">Ends</span>
+                                      ·
+                                      <span class="event__duration">
+                                        <span class="sr-only">Duration</span>
                                         <time datetime="{{ child.dateEnd }}" itemprop="endDate">
-                                          {{ child.dateEnd | localizeDate: "h:mm A" }}
-                                          <abbr title="{{ child.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                            {{ child.dateEnd | localizeDate: 'z' }}
-                                          </abbr>
+                                          <i class="fa-solid fa-timer"></i>
+                                          {{ duration_minutes }} minutes
                                         </time>
                                       </span>
                                     {% else %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -252,8 +252,14 @@ layout: layouts/base.liquid
                                     ·
                                   {% endif %}
                                   {% if child.scheduled != false %}
+
                                     {% assign parentStartDate = event.dateStart | date: "%Y-%m-%d" %}
                                     {% assign parentEndDate = event.dateEnd | date: "%Y-%m-%d" %}
+                                    {% assign start_date = child.dateStart | date: "%s" %}
+                                    {% assign end_date = child.dateEnd | date: "%s" %}
+                                    {% assign duration_seconds = end_date | minus: start_date %}
+                                    {% assign duration_minutes = duration_seconds | divided_by: 60 %}
+
                                     {% if parentEndDate == nil %}
                                       <span class="event__dateStart">
                                         <time datetime="{{ child.dateStart }}" itemprop="endDate">
@@ -292,14 +298,13 @@ layout: layouts/base.liquid
                                           </abbr>
                                         </time>
                                       </span>
-                                      <span class="event__dateEnd">
-                                        <i class="fa-solid fa-arrow-right-long"></i>
-                                        <span class="sr-only">Ends</span>
+                                      ·
+                                      <span class="event__duration">
+                                        <span class="sr-only">Duration</span>
                                         <time datetime="{{ child.dateEnd }}" itemprop="endDate">
-                                          {{ child.dateEnd | localizeDate: "MMMM D h:mm A" }}
-                                          <abbr title="{{ child.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                            {{ child.dateEnd | localizeDate: 'z' }}
-                                          </abbr>
+                                          {% comment %} stopwaatch Icon {% endcomment %}
+                                          <i class="fa-solid fa-timer"></i>
+                                          {{ duration_minutes }} minutes
                                         </time>
                                       </span>
                                     {% endif %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -255,20 +255,21 @@ layout: layouts/base.liquid
 
                                     {% assign parentStartDate = event.dateStart | date: "%Y-%m-%d" %}
                                     {% assign parentEndDate = event.dateEnd | date: "%Y-%m-%d" %}
-                                    {% assign start_date = child.dateStart | date: "%s" %}
-                                    {% assign end_date = child.dateEnd | date: "%s" %}
-                                    {% assign duration_seconds = end_date | minus: start_date %}
+                                    {% assign childStartDate = child.dateStart | date: "%s" %}
+                                    {% assign childEndDate = child.dateEnd | date: "%s" %}
+                                    {% assign duration_seconds = childEndDate | minus: childStartDate %}
                                     {% assign duration_minutes = duration_seconds | divided_by: 60 %}
 
                                     {% if parentEndDate == nil or parentStartDate == parentEndDate %}
                                       <span class="event__dateStart">
                                         <time datetime="{{ child.dateStart }}" itemprop="startDate">
                                           {{ child.dateStart | localizeDate: "h:mm A" }}
-                                          <abbr title="{{ child.dateEnd | localizeDate: 'z' | expandTimezone }}">
+                                          <abbr title="{{ child.dateStart | localizeDate: 'z' | expandTimezone }}">
                                             {{ child.dateStart | localizeDate: 'z' }}
                                           </abbr>
                                         </time>
                                       </span>
+                                      {% if child.dateEnd %}
                                       <meta itemprop="endDate" content="{{ child.dateEnd }}" />
                                       ·
                                       <span class="event__duration">
@@ -278,6 +279,7 @@ layout: layouts/base.liquid
                                           {{ duration_minutes }} minutes
                                         </time>
                                       </span>
+                                      {% endif %}
                                     {% else %}
                                       <span class="event__dateStart">
                                         <span class="sr-only">Starts</span>
@@ -288,15 +290,17 @@ layout: layouts/base.liquid
                                           </abbr>
                                         </time>
                                       </span>
-                                      <meta itemprop="endDate" content="{{ child.dateEnd }}" />
-                                      ·
-                                      <span class="event__duration">
-                                        <span class="sr-only">Duration</span>
-                                        <time datetime="PT{{ duration_minutes }}M" itemprop="duration">
-                                          <i class="fa-solid fa-timer"></i>
-                                          {{ duration_minutes }} minutes
-                                        </time>
-                                      </span>
+                                      {% if child.dateEnd %}
+                                        <meta itemprop="endDate" content="{{ child.dateEnd }}" />
+                                        ·
+                                        <span class="event__duration">
+                                          <span class="sr-only">Duration</span>
+                                          <time datetime="PT{{ duration_minutes }}M" itemprop="duration">
+                                            <i class="fa-solid fa-timer"></i>
+                                            {{ duration_minutes }} minutes
+                                          </time>
+                                        </span>
+                                        {% endif %}
                                     {% endif %}
                                   {% else %}
                                     Not yet scheduled

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -262,7 +262,7 @@ layout: layouts/base.liquid
 
                                     {% if parentEndDate == nil %}
                                       <span class="event__dateStart">
-                                        <time datetime="{{ child.dateStart }}" itemprop="endDate">
+                                        <time datetime="{{ child.dateStart }}" itemprop="startDate">
                                           {{ child.dateStart | localizeDate: "h:mm A" }}
                                           <abbr title="{{ child.dateEnd | localizeDate: 'z' | expandTimezone }}">
                                             {{ child.dateStart | localizeDate: 'z' }}
@@ -302,7 +302,6 @@ layout: layouts/base.liquid
                                       <span class="event__duration">
                                         <span class="sr-only">Duration</span>
                                         <time datetime="{{ child.dateEnd }}" itemprop="endDate">
-                                          {% comment %} stopwaatch Icon {% endcomment %}
                                           <i class="fa-solid fa-timer"></i>
                                           {{ duration_minutes }} minutes
                                         </time>


### PR DESCRIPTION
If a child event has an end date, calculate the duration in minutes based on the difference between start and end dates. Display the duration instead of the end date. Encode the duration as `itemprop="duration"` in ISO 8601 format. Encode the end date in a meta element.