### PR TITLE
27 indicate when an event has a call for speakers

### DIFF
--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -26,6 +26,8 @@
       sizes="16x16"
       href="/favicon/favicon-16x16.png">
     <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/themes/light.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/shoelace-autoloader.js"></script>
     <link rel="stylesheet" href="/styles/styles.css">
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -327,7 +327,9 @@ layout: layouts/base.liquid
                     <!-- End .event__children -->
                   {% endif %}
                   <div class="event__badges">
-                    <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
+                    <sl-tooltip placement="top-start" trigger="hover focus" content="You can apply to be a speaker at this event.">
+                      <sl-badge variant="success" pill pulse tabindex="0">Call for speakers</sl-badge>
+                    </sl-tooltip>
                   </div>
                 </article>
                 <!-- End .event -->

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -47,15 +47,15 @@ layout: layouts/base.liquid
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
                         {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                    {{ event.dateStart | localizeDate: 'z' }}
-                                                </abbr> {% endcomment %}
+                                                                              {{ event.dateStart | localizeDate: 'z' }}
+                                                                        </abbr> {% endcomment %}
                         </time>
                       {% else %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
                         {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                    {{ event.dateStart | localizeDate: 'z' }}
-                                                </abbr> {% endcomment %}
+                                                                              {{ event.dateStart | localizeDate: 'z' }}
+                                                                        </abbr> {% endcomment %}
                         </time>
                       {% endif %}
                     </span>
@@ -69,15 +69,15 @@ layout: layouts/base.liquid
                           <time datetime="{{event.dateEnd | isoDate}}" itemprop="endDate">
                             {{ event.dateEnd | localizeDate: "MMMM D" }}
                           {% comment %} <abbr title="{{ event.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                                          {{ event.dateEnd | localizeDate: 'z' }}
-                                                      </abbr> {% endcomment %}
+                                                                                      {{ event.dateEnd | localizeDate: 'z' }}
+                                                                                </abbr> {% endcomment %}
                           </time>
                         {% else %}
                           <time datetime="{{event.dateEnd | isoDate}}" itemprop="endDate">
                             {{ event.dateEnd | localizeDate: "MMMM D" }}
                           {% comment %} <abbr title="{{ event.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                                        {{ event.dateEnd | localizeDate: 'z' }}
-                                                    </abbr> {% endcomment %}
+                                                                                    {{ event.dateEnd | localizeDate: 'z' }}
+                                                                              </abbr> {% endcomment %}
                           </time>
                         {% endif %}
                       </span>
@@ -125,8 +125,8 @@ layout: layouts/base.liquid
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
                         {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                    {{ event.dateStart | localizeDate: 'z' }}
-                                                </abbr> {% endcomment %}
+                                                                              {{ event.dateStart | localizeDate: 'z' }}
+                                                                        </abbr> {% endcomment %}
                         </time>
                       {% else %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
@@ -330,9 +330,10 @@ layout: layouts/base.liquid
                     <!-- End .event__children -->
                   {% endif %}
                   <div class="event__badges">
-                    <sl-tooltip placement="top-start" trigger="hover focus" content="You can apply to be a speaker at this event.">
-                      <sl-badge variant="success" pill pulse tabindex="0">Call for speakers</sl-badge>
-                    </sl-tooltip>
+                    <sl-badge
+                      variant="success"
+                      pill
+                      pulse>Call for speakers</sl-badge>
                   </div>
                 </article>
                 <!-- End .event -->

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -46,16 +46,10 @@ layout: layouts/base.liquid
                       {% if event.day %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
-                        {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                                              {{ event.dateStart | localizeDate: 'z' }}
-                                                                        </abbr> {% endcomment %}
                         </time>
                       {% else %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
-                        {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                                              {{ event.dateStart | localizeDate: 'z' }}
-                                                                        </abbr> {% endcomment %}
                         </time>
                       {% endif %}
                     </span>
@@ -68,16 +62,10 @@ layout: layouts/base.liquid
                         {% if event.day %}
                           <time datetime="{{event.dateEnd | isoDate}}" itemprop="endDate">
                             {{ event.dateEnd | localizeDate: "MMMM D" }}
-                          {% comment %} <abbr title="{{ event.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                                                                      {{ event.dateEnd | localizeDate: 'z' }}
-                                                                                </abbr> {% endcomment %}
                           </time>
                         {% else %}
                           <time datetime="{{event.dateEnd | isoDate}}" itemprop="endDate">
                             {{ event.dateEnd | localizeDate: "MMMM D" }}
-                          {% comment %} <abbr title="{{ event.dateEnd | localizeDate: 'z' | expandTimezone }}">
-                                                                                    {{ event.dateEnd | localizeDate: 'z' }}
-                                                                              </abbr> {% endcomment %}
                           </time>
                         {% endif %}
                       </span>
@@ -124,9 +112,6 @@ layout: layouts/base.liquid
                       {% if event.day %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
                           {{ event.dateStart | localizeDate: "MMMM D" }}
-                        {% comment %} <abbr title="{{ event.dateStart | localizeDate: 'z' | expandTimezone }}">
-                                                                              {{ event.dateStart | localizeDate: 'z' }}
-                                                                        </abbr> {% endcomment %}
                         </time>
                       {% else %}
                         <time datetime="{{event.dateStart | isoDate}}" itemprop="startDate">
@@ -329,12 +314,14 @@ layout: layouts/base.liquid
                     {% endif %}
                     <!-- End .event__children -->
                   {% endif %}
-                  <div class="event__badges">
-                    <sl-badge
-                      variant="success"
-                      pill
-                      pulse>Call for speakers</sl-badge>
-                  </div>
+                  {% if event.callForSpeakers %}
+                    <div class="event__badges">
+                      <sl-badge
+                        variant="success"
+                        pill
+                        pulse>Call for speakers</sl-badge>
+                    </div>
+                  {% endif %}
                 </article>
                 <!-- End .event -->
               {% endif %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -326,6 +326,9 @@ layout: layouts/base.liquid
                     {% endif %}
                     <!-- End .event__children -->
                   {% endif %}
+                  <div class="event__badges">
+                    <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
+                  </div>
                 </article>
                 <!-- End .event -->
               {% endif %}

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -40,6 +40,11 @@
         order: 5;
         // --flow-space: var(--space-3xs-2xs);
     }
+    &__badges {
+        border-top: 1px solid rgba(0,0,0,.08);
+        order: 6;
+        padding: var(--space-xs) 0 0;
+    }
     &__type {
         background-color: var(--color-primary);
         border-radius: .2em;

--- a/src/styles/_shoelace.scss
+++ b/src/styles/_shoelace.scss
@@ -1,0 +1,3 @@
+sl-badge[variant="success"]::part(base) {
+    background-color: var(--sl-color-success-700);
+  }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,5 +1,6 @@
 @import 'reset';
 @import 'variables';
+@import 'shoelace';
 @import 'color';
 @import 'typo';
 @import 'buttons';


### PR DESCRIPTION
Displays a new 'Call for speakers' badge on an event if `callForSpeakers` is set to true in Sanity.

This is using the Badge component from Shoelace.