### PR TITLE
Render child events as a link only if website set

### DIFF
--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -201,7 +201,11 @@
                           itemscope
                           itemtype="https://schema.org/Event">
                           <span itemprop="name">
-                            <a href="{{ child.website }}">{{ child.title }}</a>
+                            {% if child.website %}
+                              <a href="{{ child.website }}">{{ child.title }}</a>
+                            {% else %}
+                              {{ child.title }}
+                            {% endif %}
                           </span>
                           <div class="event__dates text-muted">
                             {% if child.format %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -212,7 +212,11 @@ layout: layouts/base.liquid
                                 itemscope
                                 itemtype="https://schema.org/Event">
                                 <span itemprop="name">
-                                  <a href="{{ child.website }}">{{ child.title }}</a>
+                                  {% if child.website %}
+                                    <a href="{{ child.website }}">{{ child.title }}</a>
+                                  {% else %}
+                                    {{ child.title }}
+                                  {% endif %}
                                 </span>
                                 <div class="event__dates text-muted">
                                   {% if child.format %}


### PR DESCRIPTION
If a website has been set for a child event, render the title of the event as a link. If no website has been set, render it as text.

Fixes #68 