### PR TITLE
66 Exclude event from Today if its child events have ended

### DIFF
--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -84,8 +84,16 @@
         <!-- End themes -->
         </div>
         <!-- End .events -->
-      {% endif %}
+    {% endif %}
 
+      {% comment %}
+        Count the number of events in 'todaysEvents' that should be visible.
+        An event is considered visible if it has no child events or if any of its child events have not ended.
+        For each event, if it has no child events, 'visibleEventsCount' is incremented by 1.
+        If the event has child events, it checks each child event.
+        If a child event has not ended, 'visibleEventsCount' is incremented by 1 and it breaks the loop.
+        The result is that 'visibleEventsCount' contains the number of visible events.
+      {% endcomment %}
       {% assign visibleEventsCount = 0 %}
       {% for event in todaysEvents %}
         {% assign nowTimestamp = 'now' | date: "%s" %}
@@ -102,6 +110,11 @@
         {% endif %}
       {% endfor %}
 
+      {% comment %}
+        Check if there are any visible events.
+        If 'visibleEventsCount' is greater than 0, it means there are visible events.
+        If there are no visible events, the 'events' section will not be displayed.
+      {% endcomment %}
       {% if visibleEventsCount > 0 %}
         <div class="events events--list flow">
           {% for event in todaysEvents %}

--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -87,15 +87,16 @@
     {% endif %}
 
       {% comment %}
-        Count the number of events in 'todaysEvents' that should be visible.
-        An event is considered visible if it has no child events or if any of its child events have not ended.
-        For each event, if it has no child events, 'visibleEventsCount' is incremented by 1.
-        If the event has child events, it checks each child event.
-        If a child event has not ended, 'visibleEventsCount' is incremented by 1 and it breaks the loop.
-        The result is that 'visibleEventsCount' contains the number of visible events.
+        Count the number of visible events in 'todaysEvents'.
+        An event is visible if it has no child events or if any child event has not ended.
+        'visibleEventsCount' is incremented for each visible event.
+        As an optimization, the loop is skipped for the remaining events once a visible event is found.
       {% endcomment %}
       {% assign visibleEventsCount = 0 %}
       {% for event in todaysEvents %}
+        {% if visibleEventsCount > 0 %}
+          {% continue %}
+        {% endif %}
         {% assign nowTimestamp = 'now' | date: "%s" %}
         {% if event.children == empty %}
           {% assign visibleEventsCount = visibleEventsCount | plus: 1 %}

--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -91,17 +91,22 @@
           {% for event in todaysEvents %}
             {% comment %}
               Check if all child events of the current event have ended.
+              If the event has no child events, it will be displayed.
               If all child events have ended, skip the current event and move on to the next one.
             {% endcomment %}
             {% assign allChildrenEnded = true %}
-            {% assign nowTimestamp = 'now' | date: "%s" %}
-            {% for child in event.children %}
-              {% assign childEndTimestamp = child.dateEnd | date: "%s" %}
-              {% if childEndTimestamp > nowTimestamp %}
-                {% assign allChildrenEnded = false %}
-                {% break %}
-              {% endif %}
-            {% endfor %}
+            {% if event.children == empty %}
+              {% assign allChildrenEnded = false %}
+            {% else %}
+              {% assign nowTimestamp = 'now' | date: "%s" %}
+              {% for child in event.children %}
+                {% assign childEndTimestamp = child.dateEnd | date: "%s" %}
+                {% if childEndTimestamp > nowTimestamp %}
+                  {% assign allChildrenEnded = false %}
+                  {% break %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
             {% if allChildrenEnded %}
               {% continue %}
             {% endif %}

--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -91,7 +91,7 @@
           {% for event in todaysEvents %}
             {% comment %}
               Check if all child events of the current event have ended.
-              If the event has no child events, it will be displayed.
+              If the event has no child events, or if a child event doesn't have an end date, it will be displayed.
               If all child events have ended, skip the current event and move on to the next one.
             {% endcomment %}
             {% assign allChildrenEnded = true %}
@@ -100,6 +100,10 @@
             {% else %}
               {% assign nowTimestamp = 'now' | date: "%s" %}
               {% for child in event.children %}
+                {% if child.dateEnd == nil %}
+                  {% assign allChildrenEnded = false %}
+                  {% break %}
+                {% endif %}
                 {% assign childEndTimestamp = child.dateEnd | date: "%s" %}
                 {% if childEndTimestamp > nowTimestamp %}
                   {% assign allChildrenEnded = false %}

--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -89,6 +89,22 @@
       {% if todaysEvents.length > 0 %}
         <div class="events events--list flow">
           {% for event in todaysEvents %}
+            {% comment %}
+              Check if all child events of the current event have ended.
+              If all child events have ended, skip the current event and move on to the next one.
+            {% endcomment %}
+            {% assign allChildrenEnded = true %}
+            {% assign nowTimestamp = 'now' | date: "%s" %}
+            {% for child in event.children %}
+              {% assign childEndTimestamp = child.dateEnd | date: "%s" %}
+              {% if childEndTimestamp > nowTimestamp %}
+                {% assign allChildrenEnded = false %}
+                {% break %}
+              {% endif %}
+            {% endfor %}
+            {% if allChildrenEnded %}
+              {% continue %}
+            {% endif %}
             <article
               class="event event--{{ event.type }} content"
               itemprop="event"

--- a/src/_includes/today.liquid
+++ b/src/_includes/today.liquid
@@ -86,7 +86,23 @@
         <!-- End .events -->
       {% endif %}
 
-      {% if todaysEvents.length > 0 %}
+      {% assign visibleEventsCount = 0 %}
+      {% for event in todaysEvents %}
+        {% assign nowTimestamp = 'now' | date: "%s" %}
+        {% if event.children == empty %}
+          {% assign visibleEventsCount = visibleEventsCount | plus: 1 %}
+        {% else %}
+          {% for child in event.children %}
+            {% assign childEndTimestamp = child.dateEnd | date: "%s" %}
+            {% if child.dateEnd == nil or childEndTimestamp > nowTimestamp %}
+              {% assign visibleEventsCount = visibleEventsCount | plus: 1 %}
+              {% break %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+
+      {% if visibleEventsCount > 0 %}
         <div class="events events--list flow">
           {% for event in todaysEvents %}
             {% comment %}


### PR DESCRIPTION
When looping through events in Today, check if all child events of the current event have ended.

- If the event has no child events, it will be displayed.
- If all child events have ended, skip the current event and move on to the next one.

Fixes #66 